### PR TITLE
try test shell script in python

### DIFF
--- a/SiMon/tests/test.sh
+++ b/SiMon/tests/test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh\nexit 0
+python simon.py start
+python simon.py stop

--- a/SiMon/tests/test.sh
+++ b/SiMon/tests/test.sh
@@ -1,3 +1,5 @@
-#!/bin/sh\nexit 0
+#!/bin/sh
 python simon.py start
+sleep 3s
 python simon.py stop
+exit 0

--- a/SiMon/tests/test_simon.py
+++ b/SiMon/tests/test_simon.py
@@ -36,9 +36,6 @@ class TestSimon(unittest.TestCase):
 
 
     def test_daemon_mode(self):
-        s = SiMon()
-        # TODO: OSError: [Errno 8] Exec format error
-        # http://stackoverflow.com/questions/27606653/oserror-errno-8-exec-format-error
         test_dir = os.path.join(os.path.dirname(__file__), 'test.sh')
         print('test dir', test_dir)
         subprocess.call([test_dir])

--- a/SiMon/tests/test_simon.py
+++ b/SiMon/tests/test_simon.py
@@ -1,7 +1,7 @@
 from ..simon import SiMon
 import os
 import unittest
-
+import subprocess
 
 # instance a simulation_task
 
@@ -37,5 +37,9 @@ class TestSimon(unittest.TestCase):
 
     def test_daemon_mode(self):
         s = SiMon()
-        s.daemon_mode()
+        # TODO: OSError: [Errno 8] Exec format error
+        # http://stackoverflow.com/questions/27606653/oserror-errno-8-exec-format-error
+        test_dir = os.path.join(os.path.dirname(__file__), 'test.sh')
+        print('test dir', test_dir)
+        subprocess.call([test_dir])
         # TODO: start and stop does not effect?


### PR DESCRIPTION
@maxwelltsai So the way of using Python to accept user input seems very complex [link](http://stackoverflow.com/questions/21046717/python-mocking-raw-input-in-unittests), especially there would be three continuous inputs in our case, so I was thinking using `shell script` to do test.

So this PR could run without errors, but it also does not catch the error the same as #28 
