### PR TITLE
Enable command line for SiMon

### DIFF
--- a/SiMon/simon.py
+++ b/SiMon/simon.py
@@ -136,7 +136,7 @@ class SiMon(object):
             
             # mod = __import__(mod_name.split('.')[0])
             
-            print('mod_dict', mod, mod_dict)
+            #print('mod_dict', mod, mod_dict)
             # mod = __import__(module_path)
             if hasattr(mod, '__simulation__'):
                 # it is a valid SiMon module
@@ -489,22 +489,23 @@ class SiMon(object):
         daemon_runner.daemon_context.files_preserve = [handler.stream]
         daemon_runner.do_action()  # fixed time period of calling run()
 
-# if __name__ == "__main__":
-#     # execute only if run as a script
-#     if len(sys.argv) == 1:
-#         print('Running SiMon in the interactive mode...')
-#         s = SiMon()
-#         s.interactive_mode()
-#     elif len(sys.argv) > 1:
-#         if sys.argv[1] in ['start', 'stop']:
-#             # python daemon will handle these two arguments
-#             SiMon.daemon_mode(os.getcwd())
-#         elif sys.argv[1] in ['interactive', 'i']:
-#             s = SiMon()
-#             s.interactive_mode()
-#         else:
-#             SiMon.print_help()
-#             sys.exit(0)
+if __name__ == "__main__":
+    # execute only if run as a script
+    if len(sys.argv) == 1:
+        print('Running SiMon in the interactive mode...')
+        s = SiMon()
+        s.interactive_mode()
+    elif len(sys.argv) > 1:
+        if sys.argv[1] in ['start', 'stop']:
+            # python daemon will handle these two arguments
+            SiMon.daemon_mode(os.getcwd())
+        elif sys.argv[1] in ['interactive', 'i']:
+            s = SiMon()
+            s.interactive_mode()
+        else:
+            SiMon.print_help()
+            sys.exit(0)
+            
 def interactive():
     s = SiMon()
     s.interactive_mode()

--- a/SiMon/simon.py
+++ b/SiMon/simon.py
@@ -30,9 +30,13 @@ class SiMon(object):
         """
 
         # Only needed in interactive mode
-        self.config = self.parse_config_file(config_file)
+        # self.config = self.parse_config_file(os.getcwd(), config_file)
+        conf_path = os.path.join(os.getcwd(), config_file)
+        self.config = self.parse_config_file(conf_path)
+        
+        # TODO: os.getcwd() gives dir of where the current console is, eg. type simon-interactive on /SiMon will give an error, but on SiMon/Simon dir it can work.
         if self.config is None:
-            print('Error: Configure file SiMon.conf does not exist.')
+            print('Error: Configure file SiMon.conf does not exist.', conf_path)
             sys.exit(-1)
         else:
             try:
@@ -126,10 +130,18 @@ class SiMon(object):
         mod_dict = dict()
         module_candidates = glob.glob('module_*.py')
         for mod_name in module_candidates:
-            mod = __import__(mod_name.split('.')[0])
+            sys.path.append(os.getcwd())
+            import importlib
+            mod =  __import__(mod_name.split('.')[0])
+            
+            # mod = __import__(mod_name.split('.')[0])
+            
+            print('mod_dict', mod, mod_dict)
+            # mod = __import__(module_path)
             if hasattr(mod, '__simulation__'):
                 # it is a valid SiMon module
                 mod_dict[mod.__simulation__] = mod_name.split('.')[0]
+            
         return mod_dict
 
     def traverse_simulation_dir_tree(self, pattern, base_dir, files):

--- a/SiMon/simon.py
+++ b/SiMon/simon.py
@@ -477,19 +477,26 @@ class SiMon(object):
         daemon_runner.daemon_context.files_preserve = [handler.stream]
         daemon_runner.do_action()  # fixed time period of calling run()
 
-if __name__ == "__main__":
-    # execute only if run as a script
-    if len(sys.argv) == 1:
-        print('Running SiMon in the interactive mode...')
-        s = SiMon()
-        s.interactive_mode()
-    elif len(sys.argv) > 1:
-        if sys.argv[1] in ['start', 'stop']:
-            # python daemon will handle these two arguments
-            SiMon.daemon_mode(os.getcwd())
-        elif sys.argv[1] in ['interactive', 'i']:
-            s = SiMon()
-            s.interactive_mode()
-        else:
-            SiMon.print_help()
-            sys.exit(0)
+# if __name__ == "__main__":
+#     # execute only if run as a script
+#     if len(sys.argv) == 1:
+#         print('Running SiMon in the interactive mode...')
+#         s = SiMon()
+#         s.interactive_mode()
+#     elif len(sys.argv) > 1:
+#         if sys.argv[1] in ['start', 'stop']:
+#             # python daemon will handle these two arguments
+#             SiMon.daemon_mode(os.getcwd())
+#         elif sys.argv[1] in ['interactive', 'i']:
+#             s = SiMon()
+#             s.interactive_mode()
+#         else:
+#             SiMon.print_help()
+#             sys.exit(0)
+def interactive():
+    s = SiMon()
+    s.interactive_mode()
+    
+def daemon():
+    SiMon.daemon_mode(os.getcwd())
+

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 # packages are code source
 
 setup(name='astro_simon',
-      version='0.2dev',
+      version='0.2.dev0',
       description='A simulation monitor for astrophysical N-body simulations',
       url='https://github.com/maxwelltsai/SiMon',
       author='Maxwell Cai, Penny Qian',
@@ -12,4 +12,17 @@ setup(name='astro_simon',
       license='',
       packages=find_packages(),
       zip_safe=False,
-      install_requires=['python-daemon'])
+      install_requires=['python-daemon'],
+      entry_points = {
+      'console_scripts': 
+      ['simon-start = SiMon.simon:daemon',
+      'simon-stop = SiMon.simon:daemon',
+      'simon-interactive = SiMon.simon:interactive'],
+      },
+      # entry_points = """
+#       [console_scripts]
+#       simon-start = SiMon.simon:SiMon.daemon_mode
+#       simon-stop = SiMon.simon:SiMon.daemon_mode
+#       simon-interactive = SiMon.simon:SiMon.interactive_mode
+#       """
+      )


### PR DESCRIPTION
So with `python setup.py install/develop`, users can use following commands to use simon:
`simon-start` - start daemon
`simon-stop` - stop daemon
`simon-interactive` - interactive mode

While a few fix are needed:
1. path of SiMon.conf is depend on current console dir (see TODO in simon.py)
2. interactive mode does not get updated after start daemon mode, dashboard does not change
3. cheery pick the UI improvement commit - I can do it later

@maxwelltsai Can you help with 1 & 2? Thanks!