### PR TITLE
Bug fix: simulations mistakenly labeled as STALL

### DIFF
--- a/SiMon/module_common.py
+++ b/SiMon/module_common.py
@@ -308,10 +308,16 @@ class SimulationTask(object):
                 self.mtime = os.stat(output_file).st_mtime
         if self.config.has_option('Simulation', 'Timestamp_started'):
             self.ctime = self.config.getfloat('Simulation', 'Timestamp_started')
-        if self.config.has_option('Simulation', 'PID'):
-            pid = self.config.getint('Simulation', 'PID')
-            if pid == 0 and self.mtime == 0:
-                self.status = SimulationTask.STATUS_NEW
+        if os.path.isfile('.process.pid'):
+            # if the PID file exists, try to read the process ID
+            f_pid = open('.process.pid', 'r')
+            pid = int(f_pid.readline().strip())
+            f_pid.close()
+        # if self.config.has_option('Simulation', 'PID'):
+        #    pid = self.config.getint('Simulation', 'PID')
+            if pid == 0:
+                if self.mtime == 0:
+                    self.status = SimulationTask.STATUS_NEW
             else:
                 try:
                     os.kill(pid, 0)


### PR DESCRIPTION
If the user uses ic_generator to generate a parameter space, then uses
SiMon to finish the parameter space. Then generates a new parameter
space in the same directory, the finished simulations will be
mistakenly marked as STALL, because the per-simulation configuration
files are overwritten and the default pid=0, which always exists.